### PR TITLE
feat: breed cooldowns (#25)

### DIFF
--- a/src/components/breed/BreedPage.jsx
+++ b/src/components/breed/BreedPage.jsx
@@ -64,13 +64,20 @@ export default function BreedPage(props) {
         }
     };
 
-    const onBreedClicked = () => {
+    const onBreedClicked = async () => {
         if (!mum || !dad) {
             console.log('Need to select both pareents!');
             return;
         }
         console.log(`Breeding mum: ${mum.dna.dna} + dad: ${dad.dna.dna}...`);
-        Service.kitty.breed(mum.cat.kittyId, dad.cat.kittyId);
+        await Service.kitty.breed(mum.cat.kittyId, dad.cat.kittyId);
+        
+        // get updated cooldowns for parents
+        const mumUpdated = await Service.kitty.getKitty(mum.cat.kittyId);
+        setMum(new CatModel(mumUpdated));
+
+        const dadUpdated = await Service.kitty.getKitty(dad.cat.kittyId);
+        setDad(new CatModel(dadUpdated));
     }
 
     const onResetParents = ()=>{
@@ -90,7 +97,7 @@ export default function BreedPage(props) {
             {
                 data.model ? <CatBox model={data.model} /> :
                     <PlaceHolder className="bg-info">
-                        <span>Select {data.type}</span>
+                        <h1>?</h1>
                     </PlaceHolder>
             }
         </Col>
@@ -142,7 +149,7 @@ export default function BreedPage(props) {
             <h1 className="text-center">Breed Your Kitties</h1>
             <Row>
                 <Col sm={4} className="">
-                    <h5 className="text-center">Available Kitties</h5>
+                    <h5 className="text-center">Your Kitties</h5>
                     <BreedList handleOnSetParent={handleOnSetParent} />
                 </Col>
                 <Col sm={8} className="text-center">

--- a/src/components/cat/CatActions.jsx
+++ b/src/components/cat/CatActions.jsx
@@ -74,7 +74,7 @@ export default function CatActions(props) {
             .then(() => {
                 setIsApproved(true);
                 setSellStatus(SELL_STATUS.setPrice);
-                setMessage('');
+                setMessage(emptyMessage);
             })
             .catch(err => {
                 displayError(err, 'Oops...There was a problem with the approval. Try again.');

--- a/src/components/cat/CatFeatures.jsx
+++ b/src/components/cat/CatFeatures.jsx
@@ -1,7 +1,32 @@
 import React from 'react'
 import { Cattribute } from '../js/dna';
+import { useState } from 'react';
+import { useEffect } from 'react';
+import { Alert } from 'react-bootstrap';
+import moment from 'moment';
 
 export default function CatFeatures(props) {
+    const [onCooldown, setOnCooldown] = useState(false);
+    const [toReadyTxt, setToReadyTxt] = useState('');
+
+    useEffect(() => {
+        const timer = setInterval(() => {
+            const now = moment();
+            const cooldownEndTime = moment.unix(props.cat.cooldownEndTime);
+            if (now.isBefore(cooldownEndTime)) {
+                setOnCooldown(true);
+                const newReadyText = now.to(cooldownEndTime);
+                setToReadyTxt(newReadyText);
+            } else {
+                setOnCooldown(false);
+                clearInterval(timer);
+            }
+        }, 1000);
+
+        return () => clearInterval(timer);
+
+    })
+
     if (!props.cat.kittyId) {
         return null;
     }
@@ -12,9 +37,23 @@ export default function CatFeatures(props) {
             <span key={c.name}>{c.displayName}: {c.valueName}</span>
         );
 
+    const breedCountdown = onCooldown ?
+        <Alert variant="info">
+            <small>Ready to breed {toReadyTxt}</small>
+        </Alert>
+        : null;
+
     return (
         <div className="d-flex flex-column">
-            <strong># {props.cat.kittyId} Gen {props.cat.generation}</strong>
+            <strong>
+                <span># {props.cat.kittyId} </span>
+                <span>Gen {props.cat.generation} </span>
+                <span>
+                    <span role="img" aria-label="timer clock">⏲</span>
+                    <span>{props.cat.cooldown.name} ({props.cat.cooldown.durationName})</span>
+                </span>
+            </strong>
+            {breedCountdown}
             {cattributes}
         </div>
     )

--- a/src/components/js/abi.js
+++ b/src/components/js/abi.js
@@ -146,6 +146,51 @@ exports.abi =  [
     "type": "function"
   },
   {
+    "constant": true,
+    "inputs": [],
+    "name": "DNA_LENGTH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "NUM_CATTRIBUTES",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "RANDOM_DNA_THRESHOLD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "constant": false,
     "inputs": [
       {
@@ -180,6 +225,27 @@ exports.abi =  [
         "internalType": "uint256",
         "name": "balance",
         "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "cooldowns",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
       }
     ],
     "payable": false,
@@ -234,6 +300,11 @@ exports.abi =  [
         "type": "uint64"
       },
       {
+        "internalType": "uint64",
+        "name": "cooldownEndTime",
+        "type": "uint64"
+      },
+      {
         "internalType": "uint32",
         "name": "mumId",
         "type": "uint32"
@@ -244,9 +315,14 @@ exports.abi =  [
         "type": "uint32"
       },
       {
-        "internalType": "uint32",
+        "internalType": "uint16",
         "name": "generation",
-        "type": "uint32"
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "cooldownIndex",
+        "type": "uint16"
       }
     ],
     "payable": false,
@@ -705,6 +781,27 @@ exports.abi =  [
     ],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_kittyId",
+        "type": "uint256"
+      }
+    ],
+    "name": "readyToBreed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
     "type": "function"
   }
 ];

--- a/src/components/js/kitty.service.js
+++ b/src/components/js/kitty.service.js
@@ -1,9 +1,11 @@
 // import BN from 'bn.js';
 import { abi } from './abi';
+// import moment from 'moment';
 
+import { kittyCooldowns } from './kittyConstants';
 
 export class KittyService {
-    contractAddress = '0x91216e85928B02a631613C0b21c4f0a8b96c9347';
+    contractAddress = '0xe8c56AFD6F8aaA4708533c122983Bf70c80E0AbF';
     user;
     _contract;
     _contractPromise;
@@ -77,7 +79,13 @@ export class KittyService {
 
     async getKitty(id) {
         const instance = await this.getContract();
-        return instance.methods.getKitty(id).call();
+        return instance.methods
+            .getKitty(id)
+            .call()
+            .then(kitty => {
+                kitty.cooldown = kittyCooldowns[kitty.cooldownIndex];
+                return kitty;
+            });
     }
 
     async getKitties() {

--- a/src/components/js/kittyConstants.js
+++ b/src/components/js/kittyConstants.js
@@ -1,0 +1,20 @@
+import moment from 'moment';
+
+const KITTY_COOLDOWNS = [
+    { name: 'Fast', durationName: '1m', duration: moment.duration(1, 'minute') },
+    { name: 'Swift', durationName: '2m', duration: moment.duration(2, 'minutes') },
+    { name: 'Swift II', durationName: '5m', duration: moment.duration(5, 'minutes') },
+    { name: 'Snappy', durationName: '10m', duration: moment.duration(10, 'minutes') },
+    { name: 'Snappy II', durationName: '30m', duration: moment.duration(30, 'minutes') },
+    { name: 'Brisk', durationName: '1h', duration: moment.duration(1, 'hour') },
+    { name: 'Brisk II', durationName: '2h', duration: moment.duration(2, 'hours') },
+    { name: 'Plodding', durationName: '4h', duration: moment.duration(4, 'hours') },
+    { name: 'Plodding II', durationName: '8h', duration: moment.duration(8, 'hours'), },
+    { name: 'Slow', durationName: '16h', duration: moment.duration(16, 'hours') },
+    { name: 'Slow II', durationName: '1 day', duration: moment.duration(1, 'day') },
+    { name: 'Sluggish', durationName: '2 days', duration: moment.duration(2, 'days') },
+    { name: 'Sluggish II', durationName: '4 days', duration: moment.duration(4, 'days') },
+    { name: 'Catatonic', durationName: '7 days', duration: moment.duration(7, 'days') },
+];
+
+export const kittyCooldowns = KITTY_COOLDOWNS;

--- a/src/components/js/kittyMarketPlace.service.js
+++ b/src/components/js/kittyMarketPlace.service.js
@@ -3,7 +3,7 @@ import { abi } from './kittyMarketplace.abi';
 
 
 export class KittyMarketPlaceService {
-    contractAddress = '0x4ef7A4f64aD2B8B6dFAb50B39aB3B1db5DD69A65';
+    contractAddress = '0x859bbA87fe43D28DcD084D736fC49674336FA8C0';
     user;
     _contract;
     _contractPromise;

--- a/src/components/js/kittyMarketplace.abi.js
+++ b/src/components/js/kittyMarketplace.abi.js
@@ -1,254 +1,254 @@
 exports.abi = [
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_kittyContractAddress",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "constructor"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "TxType",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "tokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "MarketTransaction",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "previousOwner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnershipTransferred",
-      "type": "event"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "isOwner",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "owner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [],
-      "name": "renounceOwnership",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "transferOwnership",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_tokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "hasActiveOffer",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_kittyContractAddress",
-          "type": "address"
-        }
-      ],
-      "name": "setKittyContract",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_tokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "getOffer",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "seller",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "price",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "index",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "tokenId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bool",
-          "name": "active",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "getAllTokenOnSale",
-      "outputs": [
-        {
-          "internalType": "uint256[]",
-          "name": "listOfOffers",
-          "type": "uint256[]"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_price",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_tokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "setOffer",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_tokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "removeOffer",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_tokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "buyKitty",
-      "outputs": [],
-      "payable": true,
-      "stateMutability": "payable",
-      "type": "function"
-    }
-  ];
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_kittyContractAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "TxType",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MarketTransaction",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "hasActiveOffer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_kittyContractAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setKittyContract",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getOffer",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getAllTokenOnSale",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "listOfOffers",
+        "type": "uint256[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_price",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "setOffer",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeOffer",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyKitty",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  }
+];

--- a/src/components/market/MarketPage.jsx
+++ b/src/components/market/MarketPage.jsx
@@ -124,7 +124,7 @@ export default function MarketPage() {
                 {eventMessage.text}
             </Alert>
             {message}
-            <div>
+            <div className="d-flex flex-wrap">
                 {offerBoxes}
             </div>
         </div>


### PR DESCRIPTION
* updated contract addresses, ABIs
* Catbox now displays the cooldown interval and countdown
* Breedlist now disables the set mum/dad buttons if kitty is on cooldown
* KNOWN ISSUE: the BreedList state does not update properly after breed
   * The kitty still has the old cooldown
   * The need for Redux is increasing

Will merge this now with anticipation of migrating to Redux in a future branch.